### PR TITLE
feat: add -m args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Check your midway and component version is matched
 
 ```bash
+# check
 npx midway-version
+# update
+npx midway-version -u
+# write pkg and lock
+npx midway-version -u -w
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midway-version",
-  "version": "1.4.0-beta.7",
+  "version": "1.4.0-beta.10",
   "description": "Check your midway and component version is matched",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midway-version",
-  "version": "1.3.8",
+  "version": "1.4.0-beta.7",
   "description": "Check your midway and component version is matched",
   "main": "index.js",
   "bin": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-const { getPackage, checkPackageUpdate } = require('../index');
+const { checkPackageUpdate } = require('../index');
 
 // getPackage('@midwayjs/version').then(() => {
 //   console.log('done');


### PR DESCRIPTION
- 1、支持新的 -m 参数，以及 -m -u
- 2、支持 npm/pnpm/yarn 的识别和 lock 的写入
- 3、-m 时根据 lock 的情况，自动判断前置是否必要（有 lock，则保留前缀，否则移除前缀）
- 4、修复错误的输出提示
- 5、处理 core-decorator 文件找不到时的情况