### PR TITLE
fix: support pnpx version check for v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { execSync } = require('child_process');
 const { compareVersions, satisfies } = require('compare-versions');
 
 const currentProjectRoot = process.cwd();
-const isNpxRun = __dirname.indexOf(currentProjectRoot === -1);
+const isNpxRun = __dirname.indexOf(currentProjectRoot) === -1;
 let outputConsole = false;
 
 function detectPackageManager() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "midway-version": "bin/midway-version.js"
   },
   "dependencies": {
-    "@midwayjs/version": "^3.0.0",
+    "@midwayjs/version": "^4.0.0",
     "compare-versions": "^6.0.0"
   },
   "files": [


### PR DESCRIPTION
## Summary
- fix the runtime-location detection expression used by the npx/pnpx guard
- update @midwayjs/version dependency to ^4.0.0 so midway-version@latest includes v4 metadata

Fixes #4.

## Verification
- npm install --no-package-lock
- simulated a pnpm v4 project and ran `node bin/midway-version.js -u -w`; the command entered the update flow and no longer printed `>> Please use pnpx to run the command.`
- npm pack --dry-run